### PR TITLE
UUID update

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,30 @@
+# This workflow will build a Java project with Ant
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-ant
+
+name: Java CI
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - shell: bash
+        run: |
+          mkdir -p /home/runner/work/Framework/lastStable/archive/build/jar
+          curl https://jenkins.runsafe.no/job/Framework/lastSuccessfulBuild/artifact/build/jar/framework.jar -o ../../Framework/lastStable/archive/build/jar/framework.jar
+          cd /home/runner/work/Framework
+          git clone https://github.com/Runsafe/Framework.git
+          mv Framework workspace
+      - name: Build with Ant
+        run: ant -noinput -buildfile ant.xml

--- a/src/no/runsafe/UserControl/command/TempBan.java
+++ b/src/no/runsafe/UserControl/command/TempBan.java
@@ -52,20 +52,20 @@ public class TempBan extends ExecutableCommand implements IConfigurationChanged
 
 		playerdb.setPlayerTemporaryBan(victim, expires);
 
-		IPlayer banner = null;
+		IPlayer banningPlayer = null;
 		if (executor instanceof IPlayer)
-			banner = (IPlayer) executor;
+			banningPlayer = (IPlayer) executor;
 
-		if (!victim.isOnline() || (banner != null && banner.shouldNotSee(victim)))
+		if (!victim.isOnline() || (banningPlayer != null && banningPlayer.shouldNotSee(victim)))
 		{
-			playerManager.banPlayer(banner, victim, reason);
-			logger.logKick(banner, victim, reason, true);
-			playerdb.logPlayerBan(victim, banner, reason);
+			playerManager.banPlayer(banningPlayer, victim, reason);
+			logger.logKick(banningPlayer, victim, reason, true);
+			playerdb.logPlayerBan(victim, banningPlayer, reason);
 			return String.format("Temporarily banned offline player %s.", victim.getPrettyName());
 		}
 		if (lightning)
 			victim.strikeWithLightning(fakeLightning);
-		playerManager.banPlayer(banner, victim, reason);
+		playerManager.banPlayer(banningPlayer, victim, reason);
 		this.sendTempBanMessage(victim, executor, reason);
 		return null;
 	}

--- a/src/no/runsafe/UserControl/database/PlayerData.java
+++ b/src/no/runsafe/UserControl/database/PlayerData.java
@@ -2,6 +2,8 @@ package no.runsafe.UserControl.database;
 
 import org.joda.time.DateTime;
 
+import java.util.UUID;
+
 public class PlayerData
 {
 	public DateTime getJoined()
@@ -64,21 +66,21 @@ public class PlayerData
 		banReason = reason;
 	}
 
-	public String getBanner()
+	public UUID getBannerUUID()
 	{
-		return banner;
+		return banner_uuid;
 	}
 
-	public void setBanner(String name)
+	public void setBanner(UUID uuid)
 	{
-		banner = name;
+		banner_uuid = uuid;
 	}
 
 	private DateTime joined;
 	private DateTime login;
 	private DateTime logout;
 	private DateTime banned;
-	private String banner;
+	private UUID banner_uuid;
 	private DateTime unban;
 	private String banReason;
 }

--- a/src/no/runsafe/UserControl/database/PlayerData.java
+++ b/src/no/runsafe/UserControl/database/PlayerData.java
@@ -66,21 +66,21 @@ public class PlayerData
 		banReason = reason;
 	}
 
-	public UUID getBannerUUID()
+	public UUID getBanningPlayerUUID()
 	{
-		return banner_uuid;
+		return banningPlayerUUID;
 	}
 
-	public void setBanner(UUID uuid)
+	public void setBanningPlayer(UUID uuid)
 	{
-		banner_uuid = uuid;
+		banningPlayerUUID = uuid;
 	}
 
 	private DateTime joined;
 	private DateTime login;
 	private DateTime logout;
 	private DateTime banned;
-	private UUID banner_uuid;
+	private UUID banningPlayerUUID;
 	private DateTime unban;
 	private String banReason;
 }

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -86,7 +86,7 @@ public class PlayerDatabase extends Repository
 			"INSERT IGNORE INTO `" + getTableName() + "` " +
 				"(`uuid`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
 				"SELECT `uuid`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip` " +
-				"FROM `player_db_old`"
+				"FROM `player_db_old` WHERE `uuid` IS NOT NULL"
 		);
 
 		return update;

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -65,9 +65,9 @@ public class PlayerDatabase extends Repository
 		update.addQueries("ALTER TABLE player_db ADD COLUMN temp_ban datetime NULL");
 		update.addQueries("ALTER TABLE player_db ADD COLUMN uuid VARCHAR(255) NULL");
 
-		update.addQueries("ALTER TABLE player_db RENAME TO player_db_old");
-
-		update.addQueries( // Create new table based on player uuids instead of usernames.
+		update.addQueries(
+			"ALTER TABLE player_db RENAME TO player_db_old;",
+			// Create new table based on player uuids instead of usernames.
 			"CREATE TABLE `" + getTableName() + "` (" +
 				"`uuid` varchar(255) NOT NULL," +
 				"`name` varchar(255) NOT NULL," +
@@ -80,14 +80,12 @@ public class PlayerDatabase extends Repository
 				"`ban_by` varchar(255) NULL," +
 				"`ip` int unsigned NULL," +
 				"PRIMARY KEY(`uuid`)" +
-			")"
-		);
-
-		update.addQueries( // Migrate to new table ignoring duplicates.
+			");",
+			// Migrate to new table ignoring duplicates.
 			"INSERT IGNORE INTO `" + getTableName() + "` " +
 				"(`uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
 				"SELECT `uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip` " +
-				"FROM `player_db_old` WHERE `uuid` IS NOT NULL"
+				"FROM `player_db_old` WHERE `uuid` IS NOT NULL;"
 		);
 
 		return update;

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -74,7 +74,7 @@ public class PlayerDatabase extends Repository
 				"`login` datetime NOT NULL," +
 				"`logout` datetime NULL," +
 				"`banned` datetime NULL," +
-				"`temp_ban` VARCHAR(255) NULL" +
+				"`temp_ban` VARCHAR(255) NULL," +
 				"`ban_reason` varchar(255) NULL," +
 				"`ban_by` varchar(255) NULL," +
 				"`ip` int unsigned NULL," +
@@ -84,7 +84,7 @@ public class PlayerDatabase extends Repository
 
 		update.addQueries( // Migrate to new table ignoring duplicates.
 			"INSERT IGNORE INTO `" + getTableName() + "` " +
-				" (`uuid`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
+				"(`uuid`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
 				"SELECT `uuid`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip` " +
 				"FROM `player_db_old`"
 		);

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -70,7 +70,7 @@ public class PlayerDatabase extends Repository
 			// Add console
 			"INSERT INTO `" + getTableName() + "` " +
 				"(`name`, `joined`, `login`, `logout`, `banned`, `ban_reason`, `ban_by`, `ip`, `temp_ban`, `uuid`, ) " +
-				"VALUES ('console', '1970-01-01', '1970-01-01', '1970-01-01', NULL, NULL, NULL, NULL, NULL, '00000000-0000-0000-0000-000000000000');",
+				"VALUES ('console', '1970-01-01', '1970-01-01', '1970-01-01', NULL, NULL, NULL, NULL, NULL, '" + consoleUUID +"');",
 			// Add column for banner UUID
 			"ALTER TABLE player_db ADD COLUMN ban_by_uuid VARCHAR(36) NULL;",
 			// Convert banner usernames to UUIDs
@@ -126,7 +126,7 @@ public class PlayerDatabase extends Repository
 	{
 		database.update(
 			"UPDATE player_db SET `banned`=NOW(), ban_reason=?, ban_by=? WHERE `uuid`=?",
-			reason, banner == null ? "00000000-0000-0000-0000-000000000000" : banner, player
+			reason, banner == null ? consoleUUID : banner, player
 		);
 		dataCache.Invalidate(player);
 	}
@@ -227,6 +227,7 @@ public class PlayerDatabase extends Repository
 		return GetPlayerLogout(player) == null;
 	}
 
+	private final UUID consoleUUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
 	private final IConsole output;
 	private final IDebug console;
 	private final PlayerUsernameLog playerUsernameLog;

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -70,7 +70,7 @@ public class PlayerDatabase extends Repository
 			// Add console
 			"INSERT INTO `" + getTableName() + "` " +
 				"(`name`, `joined`, `login`, `logout`, `banned`, `ban_reason`, `ban_by`, `ip`, `temp_ban`, `uuid`, ) " +
-				"VALUES ('console', '1970-01-01', '1970-01-01', '1970-01-01', NULL, NULL, NULL, NULL, NULL, '" + consoleUUID +"');",
+				"VALUES ('console', '1970-01-01', '1970-01-01', '1970-01-01', NULL, NULL, NULL, NULL, NULL, '" + playerUsernameLog.consoleUUID +"');",
 			// Add column for banningPlayer UUID
 			"ALTER TABLE player_db ADD COLUMN ban_by_uuid VARCHAR(36) NULL;",
 			// Convert banningPlayer usernames to UUIDs
@@ -126,7 +126,7 @@ public class PlayerDatabase extends Repository
 	{
 		database.update(
 			"UPDATE player_db SET `banned`=NOW(), ban_reason=?, ban_by=? WHERE `uuid`=?",
-			reason, banningPlayer == null ? consoleUUID : banningPlayer, player
+			reason, banningPlayer == null ? playerUsernameLog.consoleUUID : banningPlayer, player
 		);
 		dataCache.Invalidate(player);
 	}
@@ -227,7 +227,6 @@ public class PlayerDatabase extends Repository
 		return GetPlayerLogout(player) == null;
 	}
 
-	private final UUID consoleUUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
 	private final IConsole output;
 	private final IDebug console;
 	private final PlayerUsernameLog playerUsernameLog;

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -67,15 +67,16 @@ public class PlayerDatabase extends Repository
 		update.addQueries("ALTER TABLE player_db ADD COLUMN uuid VARCHAR(255) NULL");
 
 		update.addQueries(
+			// Add console
+			"INSERT INTO `" + getTableName() + "` " +
+				"(`name`, `joined`, `login`, `logout`, `banned`, `ban_reason`, `ban_by`, `ip`, `temp_ban`, `uuid`, ) " +
+				"VALUES ('console', '1970-01-01', '1970-01-01', '1970-01-01', NULL, NULL, NULL, NULL, NULL, '00000000-0000-0000-0000-000000000000');",
 			// Add column for banner UUID
 			"ALTER TABLE player_db ADD COLUMN ban_by_uuid VARCHAR(36) NULL;",
 			// Convert banner usernames to UUIDs
 			"UPDATE IGNORE player_db SET `ban_by_uuid` = " +
 				"(SELECT `uuid` FROM player_db WHERE `name`=`player_db`.`ban_by`) " +
-				"WHERE `ban_by` != 'console' OR `ban_by` IS NOT NULL`;",
-			// Convert console bans to UUIDs.
-			"UPDATE IGNORE player_db SET `ban_by_uuid` = '00000000-0000-0000-0000-000000000000'" +
-				"WHERE `ban_by` == 'console';",
+				"WHERE `ban_by` IS NOT NULL`;",
 
 			"ALTER TABLE player_db RENAME TO player_db_old;",
 			// Create new table based on player uuids instead of usernames.
@@ -96,11 +97,7 @@ public class PlayerDatabase extends Repository
 			"INSERT IGNORE INTO `" + getTableName() + "` " +
 				"(`uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
 				"SELECT `uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by_uuid`, `ip` " +
-				"FROM `player_db_old` WHERE `uuid` IS NOT NULL;",
-			// Add console
-			"INSERT INTO `" + getTableName() + "` " +
-				"(`uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
-				"VALUES ('00000000-0000-0000-0000-000000000000', console, '1970-01-01', '1970-01-01', NULL, NULL, NULL, NULL, NULL);"
+				"FROM `player_db_old` WHERE `uuid` IS NOT NULL;"
 		);
 
 		return update;

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -69,15 +69,15 @@ public class PlayerDatabase extends Repository
 			"ALTER TABLE player_db RENAME TO player_db_old;",
 			// Create new table based on player uuids instead of usernames.
 			"CREATE TABLE `" + getTableName() + "` (" +
-				"`uuid` varchar(255) NOT NULL," +
-				"`name` varchar(255) NOT NULL," +
+				"`uuid` varchar(36) NOT NULL," +
+				"`name` varchar(36) NOT NULL," +
 				"`joined` datetime NOT NULL," +
 				"`login` datetime NOT NULL," +
 				"`logout` datetime NULL," +
 				"`banned` datetime NULL," +
 				"`temp_ban` VARCHAR(255) NULL," +
 				"`ban_reason` varchar(255) NULL," +
-				"`ban_by` varchar(255) NULL," +
+				"`ban_by` varchar(36) NULL," +
 				"`ip` int unsigned NULL," +
 				"PRIMARY KEY(`uuid`)" +
 			");",

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -72,7 +72,7 @@ public class PlayerDatabase extends Repository
 			// Convert banner usernames to UUIDs
 			"UPDATE IGNORE player_db SET `ban_by_uuid` = " +
 				"(SELECT `uuid` FROM player_db WHERE `name`=`player_db`.`ban_by`) " +
-				"WHERE `ban_by` != 'console';",
+				"WHERE `ban_by` != 'console' OR `ban_by` IS NOT NULL`;",
 			// Convert console bans to UUIDs.
 			"UPDATE IGNORE player_db SET `ban_by_uuid` = '00000000-0000-0000-0000-000000000000'" +
 				"WHERE `ban_by` == 'console';",

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -70,6 +70,7 @@ public class PlayerDatabase extends Repository
 		update.addQueries( // Create new table based on player uuids instead of usernames.
 			"CREATE TABLE `" + getTableName() + "` (" +
 				"`uuid` varchar(255) NOT NULL," +
+				"`name` varchar(255) NOT NULL," +
 				"`joined` datetime NOT NULL," +
 				"`login` datetime NOT NULL," +
 				"`logout` datetime NULL," +
@@ -84,8 +85,8 @@ public class PlayerDatabase extends Repository
 
 		update.addQueries( // Migrate to new table ignoring duplicates.
 			"INSERT IGNORE INTO `" + getTableName() + "` " +
-				"(`uuid`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
-				"SELECT `uuid`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip` " +
+				"(`uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
+				"SELECT `uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip` " +
 				"FROM `player_db_old` WHERE `uuid` IS NOT NULL"
 		);
 
@@ -103,9 +104,9 @@ public class PlayerDatabase extends Repository
 	{
 		console.debugFine("Updating player_db with login time");
 		database.update(
-			"INSERT INTO player_db (`uuid`,`joined`,`login`,`ip`) VALUES (?,NOW(),NOW(),INET_ATON(?))" +
-				"ON DUPLICATE KEY UPDATE `uuid`=VALUES(`uuid`), `login`=VALUES(`login`), `ip`=VALUES(`ip`)",
-			player, player.getIP()
+			"INSERT INTO player_db (`uuid`, `name`, `joined`,`login`,`ip`) VALUES (?,?,NOW(),NOW(),INET_ATON(?))" +
+				"ON DUPLICATE KEY UPDATE `uuid`=VALUES(`uuid`), `name`=VALUES(`name`), `login`=VALUES(`login`), `ip`=VALUES(`ip`)",
+			player, player.getName(), player.getIP()
 		);
 		dataCache.Invalidate(player);
 		playerUsernameLog.purgeLookupCache();

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -97,7 +97,7 @@ public class PlayerDatabase extends Repository
 
 	public void setPlayerTemporaryBan(IPlayer player, DateTime temporary)
 	{
-		database.update("UPDATE player_db SET temp_ban=? WHERE `name`=?", temporary, player.getName());
+		database.update("UPDATE player_db SET temp_ban=? WHERE `uuid`=?", temporary, player.getName());
 		dataCache.Invalidate(player);
 	}
 

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -96,7 +96,11 @@ public class PlayerDatabase extends Repository
 			"INSERT IGNORE INTO `" + getTableName() + "` " +
 				"(`uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
 				"SELECT `uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by_uuid`, `ip` " +
-				"FROM `player_db_old` WHERE `uuid` IS NOT NULL;"
+				"FROM `player_db_old` WHERE `uuid` IS NOT NULL;",
+			// Add console
+			"INSERT INTO `" + getTableName() + "` " +
+				"(`uuid`, `name`, `joined`, `login`, `logout`, `banned`, `temp_ban`, `ban_reason`, `ban_by`, `ip`) " +
+				"VALUES ('00000000-0000-0000-0000-000000000000', console, '1970-01-01', '1970-01-01', NULL, NULL, NULL, NULL, NULL);"
 		);
 
 		return update;

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -122,7 +122,7 @@ public class PlayerDatabase extends Repository
 
 	public void setPlayerTemporaryBan(IPlayer player, DateTime temporary)
 	{
-		database.update("UPDATE player_db SET temp_ban=? WHERE `uuid`=?", temporary, player.getName());
+		database.update("UPDATE player_db SET temp_ban=? WHERE `uuid`=?", temporary, player);
 		dataCache.Invalidate(player);
 	}
 

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -114,7 +114,7 @@ public class PlayerDatabase extends Repository
 	{
 		console.debugFine("Updating player_db with login time");
 		database.update(
-			"INSERT INTO player_db (`uuid`, `name`, `joined`,`login`,`ip`) VALUES (?,?,NOW(),NOW(),INET_ATON(?))" +
+			"INSERT INTO player_db (`uuid`,`name`,`joined`,`login`,`ip`) VALUES (?,?,NOW(),NOW(),INET_ATON(?))" +
 				"ON DUPLICATE KEY UPDATE `uuid`=VALUES(`uuid`), `name`=VALUES(`name`), `login`=VALUES(`login`), `ip`=VALUES(`ip`)",
 			player, player.getName(), player.getIP()
 		);

--- a/src/no/runsafe/UserControl/database/PlayerDatabase.java
+++ b/src/no/runsafe/UserControl/database/PlayerDatabase.java
@@ -71,9 +71,9 @@ public class PlayerDatabase extends Repository
 			"INSERT INTO `" + getTableName() + "` " +
 				"(`name`, `joined`, `login`, `logout`, `banned`, `ban_reason`, `ban_by`, `ip`, `temp_ban`, `uuid`, ) " +
 				"VALUES ('console', '1970-01-01', '1970-01-01', '1970-01-01', NULL, NULL, NULL, NULL, NULL, '" + consoleUUID +"');",
-			// Add column for banner UUID
+			// Add column for banningPlayer UUID
 			"ALTER TABLE player_db ADD COLUMN ban_by_uuid VARCHAR(36) NULL;",
-			// Convert banner usernames to UUIDs
+			// Convert banningPlayer usernames to UUIDs
 			"UPDATE IGNORE player_db SET `ban_by_uuid` = " +
 				"(SELECT `uuid` FROM player_db WHERE `name`=`player_db`.`ban_by`) " +
 				"WHERE `ban_by` IS NOT NULL`;",
@@ -122,11 +122,11 @@ public class PlayerDatabase extends Repository
 		playerUsernameLog.purgeLookupCache();
 	}
 
-	public void logPlayerBan(IPlayer player, IPlayer banner, String reason)
+	public void logPlayerBan(IPlayer player, IPlayer banningPlayer, String reason)
 	{
 		database.update(
 			"UPDATE player_db SET `banned`=NOW(), ban_reason=?, ban_by=? WHERE `uuid`=?",
-			reason, banner == null ? consoleUUID : banner, player
+			reason, banningPlayer == null ? consoleUUID : banningPlayer, player
 		);
 		dataCache.Invalidate(player);
 	}
@@ -168,7 +168,7 @@ public class PlayerDatabase extends Repository
 			output.logInformation("Player %s with UUID %s changed their username!", player.getName(), raw.String("uuid"));
 		data = new PlayerData();
 		data.setBanned(raw.DateTime("banned"));
-		data.setBanner(UUID.fromString(raw.String("ban_by")));
+		data.setBanningPlayer(UUID.fromString(raw.String("ban_by")));
 		data.setBanReason(raw.String("ban_reason"));
 		data.setJoined(raw.DateTime("joined"));
 		data.setLogin(raw.DateTime("login"));
@@ -190,7 +190,7 @@ public class PlayerDatabase extends Repository
 			result.put("usercontrol.ban.reason", data.getBanReason());
 			if (data.getUnban() != null)
 				result.put("usercontrol.ban.temporary", DATE_FORMAT.print(data.getUnban()));
-			result.put("usercontrol.ban.by", playerUsernameLog.getLatestUsername(data.getBannerUUID()));
+			result.put("usercontrol.ban.by", playerUsernameLog.getLatestUsername(data.getBanningPlayerUUID()));
 		}
 		else
 			result.put("usercontrol.ban.status", "false");

--- a/src/no/runsafe/UserControl/database/PlayerUsernameLog.java
+++ b/src/no/runsafe/UserControl/database/PlayerUsernameLog.java
@@ -108,6 +108,9 @@ public class PlayerUsernameLog extends Repository implements IPlayerLookupServic
 	@Nullable
 	public String getLatestUsername(UUID playerId)
 	{
+		if(playerId.toString().equals("00000000-0000-0000-0000-000000000000"))
+			return "Console";
+
 		List<String> playerNames = getUsedUsernames(playerId);
 
 		if (playerNames == null)

--- a/src/no/runsafe/UserControl/database/PlayerUsernameLog.java
+++ b/src/no/runsafe/UserControl/database/PlayerUsernameLog.java
@@ -47,6 +47,10 @@ public class PlayerUsernameLog extends Repository implements IPlayerLookupServic
 			"INSERT INTO `" + getTableName() + "` (`uuid`, `name`, `last_login`) " +
 				"SELECT `uuid`, `name`, `login` from `player_db`"
 		);
+		update.addQueries(
+			"INSERT INTO `" + getTableName() + "` (`uuid`, `name`, `last_login`) " +
+				"VALUES ('00000000-0000-0000-0000-000000000000', console, '1970-01-01');"
+		);
 
 		return update;
 	}
@@ -108,9 +112,6 @@ public class PlayerUsernameLog extends Repository implements IPlayerLookupServic
 	@Nullable
 	public String getLatestUsername(UUID playerId)
 	{
-		if(playerId.toString().equals("00000000-0000-0000-0000-000000000000"))
-			return "Console";
-
 		List<String> playerNames = getUsedUsernames(playerId);
 
 		if (playerNames == null)

--- a/src/no/runsafe/UserControl/database/PlayerUsernameLog.java
+++ b/src/no/runsafe/UserControl/database/PlayerUsernameLog.java
@@ -49,7 +49,7 @@ public class PlayerUsernameLog extends Repository implements IPlayerLookupServic
 		);
 		update.addQueries(
 			"INSERT INTO `" + getTableName() + "` (`uuid`, `name`, `last_login`) " +
-				"VALUES ('00000000-0000-0000-0000-000000000000', console, '1970-01-01');"
+				"VALUES ('" + consoleUUID + "', console, '1970-01-01');"
 		);
 
 		return update;
@@ -197,6 +197,7 @@ public class PlayerUsernameLog extends Repository implements IPlayerLookupServic
 		lookupCache.Purge();
 	}
 
+	public final UUID consoleUUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
 	private final Pattern SQLWildcard = Pattern.compile("([%_])");
 	private final TimedCache<String, List<String>> lookupCache;
 	private final TimedCache<String, List<UUID>> uniqueIdCache;


### PR DESCRIPTION
Updates the main player_db to use UUID as a primary key instead of username. Fixes issues relating to players who change their username.

Usernames are not stored in the new database due to there being a separate database that already keeps track of usernames.

Possible data loss with updating joined date in users who have changed their username, which is why the old database has been kept.  I do not expect for there to be additional issues caused by this due to current behavior already often showing the wrong joined date in players who have already changed their usernames.  Having the old database gives a chance to correct this manually.